### PR TITLE
fix: syntaxe SupporterRepository + Match

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,43 @@
 # TP-Tournoi-Foot
-M2i 2iTech - Semaine7 : Java Spring Boot
+
+## Contexte
+
+Cette application s'inscrit dans le cursus M2i 2iTech
+, pour l'obtention du titre de Concepteur et Développeur d'Application (CDA).
+
+Le but étant de pouvoir évaluer nos compétences de conception et développement dans une API Rest
+, pour le langage Java Spring boot.
+
+---
+
+### Technologies :
+- JDK 21
+- Java 17
+- Spring boot : 3.2.3
+- MySQL
+
+### Git :
+- https://github.com/AntoineValenduc/TP-Tournoi-Foot
+
+### Docker :
+
+- Pour lancer le conteneur, inscrivez dans la console `docker compose up -d`.
+- Pour fermer le controller avec ses volumes, inscrivez dans la console `docker compose down -v`.
+
+---
+
+## Présentation
+
+Il s'agit d'une application de gestion de match de foot.
+
+Elle permet de générer des matchs de composition d'équipe aléatoire.
+Avec un système de réservation de tickets pour les matchs, ainsi que de paris.
+
+---
+
+## Fonctionnalités principales
+
+- Réserver un ou plusieurs ticket(s) pour un supporter.
+- Réserver un ticket à partir du match
+- Faire un pari sur la réussite d'une équipe lors d'un match
+- Système de quotation des équipes pour définir la valeur du pari

--- a/src/main/java/org/example/tptournoifoot/match/Match.java
+++ b/src/main/java/org/example/tptournoifoot/match/Match.java
@@ -1,10 +1,9 @@
 package org.example.tptournoifoot.match;
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.example.tptournoifoot.arbitre.Arbitre;
 import org.example.tptournoifoot.equipe.Equipe;
 import org.example.tptournoifoot.stade.Stade;
@@ -21,9 +20,12 @@ import java.util.List;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@ToString
+@Table(name = "matchFoot")
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
 public class Match {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.AUTO)
     private Integer id;
 
     @Column

--- a/src/main/java/org/example/tptournoifoot/supporter/SupporterRepository.java
+++ b/src/main/java/org/example/tptournoifoot/supporter/SupporterRepository.java
@@ -6,5 +6,5 @@ import java.util.Optional;
 
 public interface SupporterRepository extends JpaRepository<Supporter, Integer> {
 
-    Optional<Supporter> findByNomSupporter(String nom);
+    Optional<Supporter> findByNom(String nom);
 }

--- a/src/main/java/org/example/tptournoifoot/supporter/SupporterService.java
+++ b/src/main/java/org/example/tptournoifoot/supporter/SupporterService.java
@@ -47,7 +47,7 @@ public class SupporterService {
 
     // GET Par nom du supporter
     public Supporter findByNomSupporter(String nom){
-        return supporterRepository.findByNomSupporter(nom).orElseThrow(
+        return supporterRepository.findByNom(nom).orElseThrow(
                 ()-> new ResponseStatusException(
                         HttpStatus.NOT_FOUND,
                         "Aucuns supporter trouvé avec pour nom" + nom


### PR DESCRIPTION
Modification de la syntaxe de la méthode findByNomSupporter => findByNom
Modification de la syntaxe du nom de la classe match => matchFoot, qui ne permettait tout simplement pas de créer la classe en BDD